### PR TITLE
Extra confirmation before wiping LocalStorage

### DIFF
--- a/gambL.js
+++ b/gambL.js
@@ -916,10 +916,12 @@ document.querySelector("#saveP").addEventListener("click", (e) => {
     }
 })
 document.querySelector("#deleteP").addEventListener("click", (e) => {
-    if (confirm("Are you super sure?")) {
-        localStorage.clear()
-        alert("Bye bye!")
-        location.reload()
+    if(confirm("Are you sure?")) {
+        if (confirm("Are you super sure?")) {
+            localStorage.clear()
+            alert("Bye bye!")
+            location.reload()
+        }
     }
 })
 //save load


### PR DESCRIPTION
Added a 'if' function containing the previous 'if' confirmation for wiping LocalStorage in the Settings division. The added 'if' function should create a 'confirm' prompt before a second 'confirm' prompt which leads to LocalStorage clear.